### PR TITLE
feat: Add annotation to the ingress objects

### DIFF
--- a/jxboot-resources/templates/700-bucketrepo-ing.yaml
+++ b/jxboot-resources/templates/700-bucketrepo-ing.yaml
@@ -4,6 +4,9 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
+{{- if .Values.cluster.ingress.annotations }}
+{{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
+{{- end }}
   name: bucketrepo
 spec:
   rules:

--- a/jxboot-resources/templates/700-chartmuseum-ing.yaml
+++ b/jxboot-resources/templates/700-chartmuseum-ing.yaml
@@ -4,6 +4,9 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
+{{- if .Values.cluster.ingress.annotations }}
+{{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
+{{- end }}
   name: chartmuseum
 spec:
   rules:

--- a/jxboot-resources/templates/700-deck-ing.yaml
+++ b/jxboot-resources/templates/700-deck-ing.yaml
@@ -6,6 +6,9 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/auth-secret: jx-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
+{{- if .Values.cluster.ingress.annotations }}
+{{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
+{{- end }}
   name: deck
 spec:
   rules:

--- a/jxboot-resources/templates/700-docker-ing.yaml
+++ b/jxboot-resources/templates/700-docker-ing.yaml
@@ -6,6 +6,9 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/auth-secret: jx-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
+{{- if .Values.cluster.ingress.annotations }}
+{{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
+{{- end }}
   name: docker-registry
 spec:
   rules:

--- a/jxboot-resources/templates/700-hook-ing.yaml
+++ b/jxboot-resources/templates/700-hook-ing.yaml
@@ -5,6 +5,9 @@ metadata:
   name: hook
   annotations:
     kubernetes.io/ingress.class: nginx
+{{- if .Values.cluster.ingress.annotations }}
+{{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   rules:
   - host: hook{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}

--- a/jxboot-resources/templates/700-jenkins-ing.yaml
+++ b/jxboot-resources/templates/700-jenkins-ing.yaml
@@ -6,6 +6,9 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/auth-secret: jx-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
+{{- if .Values.cluster.ingress.annotations }}
+{{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
+{{- end }}
   name: jenkins
 spec:
   rules:

--- a/jxboot-resources/templates/700-nexus-ing.yaml
+++ b/jxboot-resources/templates/700-nexus-ing.yaml
@@ -4,6 +4,9 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
+{{- if .Values.cluster.ingress.annotations }}
+{{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
+{{- end }}
   name: nexus
 spec:
   rules:

--- a/jxboot-resources/templates/700-tide-ing.yaml
+++ b/jxboot-resources/templates/700-tide-ing.yaml
@@ -6,6 +6,9 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/auth-secret: jx-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
+{{- if .Values.cluster.ingress.annotations }}
+{{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
+{{- end }}
   name: tide
 spec:
   rules:

--- a/jxboot-resources/values.yaml
+++ b/jxboot-resources/values.yaml
@@ -18,6 +18,9 @@ cluster:
   projectID: ""
   serverUrl: ""
   zone: ""
+  ingress:
+    annotations:
+#      kubernetes.io/ingress.class: nginx
 docker-registry:
   enabled: false
 gitops:


### PR DESCRIPTION
Using the Nginx annotation users can configure additional feature for ingress.

Reference https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/

The use can define annotation in the values.yaml file under the cluster.ingress.annotation as a map key - value. 

For example:
```
cluster:
  ingress:
    annotation:
      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
      nginx.ingress.kubernetes.io/auth-realm: Pre-Authentication Required
      nginx.ingress.kubernetes.io/configuration-snippet: |
        satisfy any;
        allow 192.10.11.12/32;
        allow 212.9.212.5/32;
        
        deny all;
```

fixes issue #16 