### PR TITLE
fix: Quote true boolean in namespace template labels

### DIFF
--- a/jxboot-resources/templates/000-namespace.yaml
+++ b/jxboot-resources/templates/000-namespace.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     env: dev
     team: jx
-    certmanager.k8s.io/disable-validation: true
+    certmanager.k8s.io/disable-validation: "true"
   name: jx
 spec:
   finalizers:


### PR DESCRIPTION
Otherwise, kubectl 1.17.0 and later will always error on it. Previously it was just discarded.