### PR TITLE
fix: Default namespace for staging env should be staging, not production

### DIFF
--- a/jxboot-resources/templates/staging-env.yaml
+++ b/jxboot-resources/templates/staging-env.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kind: Permanent
   label: Staging
-  namespace: {{ .Values.gitops.production.namespace }}
+  namespace: {{ .Values.gitops.staging.namespace }}
   order: 100
   previewGitInfo:
     user: {}


### PR DESCRIPTION
Fixing an issue introduced by #20

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>