### PR TITLE
fix: Dev env URLs should be set in SourceRepository

### DIFF
--- a/jxboot-resources/templates/dev-repo.yaml
+++ b/jxboot-resources/templates/dev-repo.yaml
@@ -7,9 +7,12 @@ metadata:
     jenkins.io/gitSync: "false"
 spec:
   provider: "{{ .Values.gitops.dev.server | default .Values.gitops.server }}"
-  providerName: '{{ .Values.gitops.gitKind | default "github" }}'
+  providerName: '{{ .Values.gitops.gitName | default .Values.gitops.gitKind | default "github" }}'
+  providerKind: '{{ .Values.gitops.gitKind | default "github" }}'
   org: "{{ .Values.gitops.dev.owner | default .Values.gitops.owner }}"
   repo: "{{ .Values.gitops.dev.repo }}"
+  url: "{{ .Values.gitops.dev.server | default .Values.gitops.server }}{{ .Values.gitops.gitUrlPathPrefix}}/{{ .Values.gitops.dev.owner | default .Values.gitops.owner }}/{{ .Values.gitops.dev.repo }}.git"
+  httpCloneURL: "{{ .Values.gitops.dev.server | default .Values.gitops.server }}{{ .Values.gitops.gitUrlPathPrefix}}/{{ .Values.gitops.dev.owner | default .Values.gitops.owner }}/{{ .Values.gitops.dev.repo }}.git"
   description: "the git repository for the Dev environment - used to manage the Jenkins X installation"
   scheduler:
     kind: Scheduler


### PR DESCRIPTION
We do this already for the staging and production environment
`SourceRepository`s, but for some reason we don't for the development
environment. Let's fix that.

fixes https://github.com/jenkins-x/jx/issues/6617

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>