### PR TITLE
fix_IssueWithBasicAuth_For_StaticJX

### DIFF
--- a/jxboot-resources/templates/700-jenkins-ing.yaml
+++ b/jxboot-resources/templates/700-jenkins-ing.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/auth-secret: jx-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}


### PR DESCRIPTION
when static jenkins x is installed using jx boot, and used vault for storing secrets, whilst set fabric.io/expose="false", this line is causing problems, we had to enter credentials twice. I believe removing this lie will fix the issue.