### PR TITLE
fix: basic auth issue with static jx

### DIFF
--- a/jxboot-resources/templates/700-jenkins-ing.yaml
+++ b/jxboot-resources/templates/700-jenkins-ing.yaml
@@ -4,8 +4,6 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/auth-secret: jx-basic-auth
-    nginx.ingress.kubernetes.io/auth-type: basic
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
 {{- end }}


### PR DESCRIPTION
When static jenkins x is installed using jx boot, and set fabric.io/expose="false", jenkins server is requesting for basic auth details and throwing 401 error. Removing this annotation will fix the issue. 