### PR TITLE
fix: different tls secret per ingress

### DIFF
--- a/jxboot-resources/templates/700-bucketrepo-ing.yaml
+++ b/jxboot-resources/templates/700-bucketrepo-ing.yaml
@@ -20,7 +20,11 @@ spec:
   tls:
   - hosts:
     - bucketrepo{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
-{{- if eq .Values.certmanager.production "true" }}
+{{- if .Values.bucketrepo.ingress.tls.secretName }}
+    secretName: "{{ .Values.bucketrepo.ingress.tls.secretName }}"
+{{- else if .Values.cluster.ingress.tls.secretName }}
+    secretName: "{{ .Values.cluster.ingress.tls.secretName }}"
+{{- else if eq .Values.certmanager.production "true" }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"

--- a/jxboot-resources/templates/700-chartmuseum-ing.yaml
+++ b/jxboot-resources/templates/700-chartmuseum-ing.yaml
@@ -1,5 +1,5 @@
 {{- if index .Values "jenkins-x-platform" "chartmuseum" "enabled" }}
-{{- if index .Values "jenkins-x-platform" "chartmuseum" "ingress" }}
+{{- if index .Values "jenkins-x-platform" "chartmuseum" "ingress" "enabled" }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -21,7 +21,11 @@ spec:
   tls:
   - hosts:
     - chartmuseum{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
-{{- if eq .Values.certmanager.production "true" }}
+{{- if index .Values "jenkins-x-platform" "chartmuseum" "ingress" "tls" "secretName" }}
+    secretName: "{{ index .Values "jenkins-x-platform" "chartmuseum" "ingress" "tls" "secretName" }}"
+{{- else if .Values.cluster.ingress.tls.secretName }}
+    secretName: "{{ .Values.cluster.ingress.tls.secretName }}"
+{{- else if eq .Values.certmanager.production "true" }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"

--- a/jxboot-resources/templates/700-deck-ing.yaml
+++ b/jxboot-resources/templates/700-deck-ing.yaml
@@ -22,7 +22,11 @@ spec:
   tls:
   - hosts:
     - deck{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
-{{- if eq .Values.certmanager.production "true" }}
+{{- if .Values.deck.ingress.tls.secretName }}
+    secretName: "{{ .Values.deck.ingress.tls.secretName }}"
+{{- else if .Values.cluster.ingress.tls.secretName }}
+    secretName: "{{ .Values.cluster.ingress.tls.secretName }}"
+{{- else if eq .Values.certmanager.production "true" }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"

--- a/jxboot-resources/templates/700-docker-ing.yaml
+++ b/jxboot-resources/templates/700-docker-ing.yaml
@@ -22,7 +22,11 @@ spec:
   tls:
   - hosts:
     - docker-registry{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
-{{- if eq .Values.certmanager.production "true" }}
+{{- if index .Values "docker-registry" "ingress" "tls" "secretName" }}
+    secretName: "{{ index .Values "docker-registry" "ingress" "tls" "secretName" }}"
+{{- else if .Values.cluster.ingress.tls.secretName }}
+    secretName: "{{ .Values.cluster.ingress.tls.secretName }}"
+{{- else if eq .Values.certmanager.production "true" }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"

--- a/jxboot-resources/templates/700-hook-ing.yaml
+++ b/jxboot-resources/templates/700-hook-ing.yaml
@@ -20,7 +20,11 @@ spec:
   tls:
   - hosts:
     - hook{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
-{{- if eq .Values.certmanager.production "true" }}
+{{- if .Values.hook.ingress.tls.secretName }}
+    secretName: "{{ .Values.hook.ingress.tls.secretName }}"
+{{- else if .Values.cluster.ingress.tls.secretName }}
+    secretName: "{{ .Values.cluster.ingress.tls.secretName }}"
+{{- else if eq .Values.certmanager.production "true" }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"

--- a/jxboot-resources/templates/700-jenkins-ing.yaml
+++ b/jxboot-resources/templates/700-jenkins-ing.yaml
@@ -20,7 +20,11 @@ spec:
   tls:
   - hosts:
     - jenkins{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
-{{- if eq .Values.certmanager.production "true" }}
+{{- if .Values.jenkins.ingress.tls.secretName }}
+    secretName: "{{ .Values.jenkins.ingress.tls.secretName }}"
+{{- else if .Values.cluster.ingress.tls.secretName }}
+    secretName: "{{ .Values.cluster.ingress.tls.secretName }}"
+{{- else if eq .Values.certmanager.production "true" }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"

--- a/jxboot-resources/templates/700-nexus-ing.yaml
+++ b/jxboot-resources/templates/700-nexus-ing.yaml
@@ -20,7 +20,11 @@ spec:
   tls:
   - hosts:
     - nexus{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
-{{- if eq .Values.certmanager.production "true" }}
+{{- if .Values.nexus.ingress.tls.secretName }}
+    secretName: "{{ .Values.nexus.ingress.tls.secretName }}"
+{{- else if .Values.cluster.ingress.tls.secretName }}
+    secretName: "{{ .Values.cluster.ingress.tls.secretName }}"
+{{- else if eq .Values.certmanager.production "true" }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"

--- a/jxboot-resources/templates/700-tide-ing.yaml
+++ b/jxboot-resources/templates/700-tide-ing.yaml
@@ -22,7 +22,11 @@ spec:
   tls:
   - hosts:
     - tide{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
-{{- if eq .Values.certmanager.production "true" }}
+{{- if .Values.tide.ingress.tls.secretName }}
+    secretName: "{{ .Values.tide.ingress.tls.secretName }}"
+{{- else if .Values.cluster.ingress.tls.secretName }}
+    secretName: "{{ .Values.cluster.ingress.tls.secretName }}"
+{{- else if eq .Values.certmanager.production "true" }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"

--- a/jxboot-resources/values.yaml
+++ b/jxboot-resources/values.yaml
@@ -5,6 +5,9 @@ bucketrepo:
   enabled: false
   password: ""
   username: ""
+  ingress:
+    tls:
+      secretName: ""
 certmanager:
   enabled: false
   production: "false"
@@ -19,10 +22,15 @@ cluster:
   serverUrl: ""
   zone: ""
   ingress:
+    tls:
+      secretName: ""
     annotations:
 #      kubernetes.io/ingress.class: nginx
 docker-registry:
   enabled: false
+  ingress:
+    tls:
+      secretName: ""
 gitops:
   dev:
     dockerRegistryOrg: ""
@@ -68,19 +76,38 @@ gitops:
 hook:
   ingress:
     class: nginx
+    tls:
+      secretName: ""
 jenkins:
   enabled: false
+  ingress:
+    tls:
+      secretName: ""
 jenkins-x-platform:
   chartmuseum:
     enabled: true
-    ingress: true
+    ingress:
+      enabled: true
+      tls:
+        secretName: ""
 lighthouse:
   enabled: true
 mergeUpdatebotPRs: true
 nexus:
   enabled: true
+  ingress:
+    tls:
+      secretName: ""
 prow:
   enabled: false
+tide:
+  ingress:
+    tls:
+      secretName: ""
+deck:
+  ingress:
+    tls:
+      secretName: ""
 storage:
   logs:
     url: ""


### PR DESCRIPTION
Signed-off-by: Youssef El Houti <youssef.elhouti@gmail.com>

### For reviewers
The goal here is for lets-encrypt to automatically generate certificates per ingress and avoid having to handle that manually, specially if your cluster already have issuers installed.
This is done by editing the jx-requirements and adding
```
  ingress:
    annotations:
      cert-manager.io/cluster-issuer: letsencrypt-prod
```
in env/jxboot-resources/values.tmpl.yaml (or editing env/values.tmpl.yaml with the extra key)
This would work for both clusters with already installed cert-managers and new ones with cert-managers and issuers created by jenkins-x

fixes #31 , https://github.com/jenkins-x/jx/issues/5310