### PR TITLE
feat(hook): allow custom ingress class

### DIFF
--- a/jxboot-resources/templates/700-hook-ing.yaml
+++ b/jxboot-resources/templates/700-hook-ing.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   name: hook
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: {{ .Values.hook.ingress.class }}
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
 {{- end }}

--- a/jxboot-resources/values.yaml
+++ b/jxboot-resources/values.yaml
@@ -65,6 +65,9 @@ gitops:
   versionStreamRef: ""
   versionStreamUrl: https://github.com/jenkins-x/jenkins-x-versions.git
   webhook: ""
+hook:
+  ingress:
+    class: nginx
 jenkins:
   enabled: false
 jenkins-x-platform:


### PR DESCRIPTION
the nginx ingress controller created by jx is accessible to the internet by default. enterprise installations need the ability to limit access to jx resources to a private subnet/vpn and still keep hook exposed to the internet. we are already able to set
```yaml
controller:
  service:
    annotations:
      cloud.google.com/load-balancer-type: "internal"
```
on the nginx chart via helmfile app values overrides. my change would allow jx-requirements.yml to override the hook ingress class annotation to use a public ingress while keeping the default jenkins-x nginx ingress internal/vpn-only.

an alternative would be something like #27 where we disable the default ingress resource for hook entirely, and rely on the user to create their own.

P.S. do i need to write tests for this repo? are there any affected repos/docs I need to update?
