### PR TITLE
fix: use regex for branches

### DIFF
--- a/jxboot-resources/templates/default-scheduler.yaml
+++ b/jxboot-resources/templates/default-scheduler.yaml
@@ -45,7 +45,7 @@ spec:
     - agent: tekton
       branches:
         entries:
-        - master
+        - ^master$
       cluster: ""
       context: ""
       labels: {}

--- a/jxboot-resources/templates/env-scheduler.yaml
+++ b/jxboot-resources/templates/env-scheduler.yaml
@@ -45,7 +45,7 @@ spec:
     - agent: tekton
       branches:
         entries:
-        - master
+        - ^master$
       cluster: ""
       context: ""
       labels: {}

--- a/jxboot-resources/templates/release-only-scheduler.yaml
+++ b/jxboot-resources/templates/release-only-scheduler.yaml
@@ -45,7 +45,7 @@ spec:
     - agent: tekton
       branches:
         entries:
-        - master
+        - ^master$
       cluster: ""
       context: ""
       labels: {}


### PR DESCRIPTION
ref: https://github.com/kubernetes/test-infra/issues/11779
Now, release job will be executed if we push commits to `xx-master-yy` branch.
So I think we should use exact match for branch specifications.