### PR TITLE
feat: allow per-ingress annotations

### DIFF
--- a/jxboot-resources/templates/700-bucketrepo-ing.yaml
+++ b/jxboot-resources/templates/700-bucketrepo-ing.yaml
@@ -7,6 +7,9 @@ metadata:
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
 {{- end }}
+{{- if .Values.bucketrepo.ingress.annotations }}
+{{ toYaml .Values.bucketrepo.ingress.annotations | indent 4 }}
+{{- end }}
   name: bucketrepo
 spec:
   rules:

--- a/jxboot-resources/templates/700-chartmuseum-ing.yaml
+++ b/jxboot-resources/templates/700-chartmuseum-ing.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
 {{- end }}
+{{- if .Values.chartmuseum.ingress.annotations }}
+{{ toYaml .Values.chartmuseum.ingress.annotations | indent 4 }}
+{{- end }}
   name: chartmuseum
 spec:
   rules:

--- a/jxboot-resources/templates/700-deck-ing.yaml
+++ b/jxboot-resources/templates/700-deck-ing.yaml
@@ -9,6 +9,9 @@ metadata:
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
 {{- end }}
+{{- if .Values.deck.ingress.annotations }}
+{{ toYaml .Values.deck.ingress.annotations | indent 4 }}
+{{- end }}
   name: deck
 spec:
   rules:

--- a/jxboot-resources/templates/700-docker-ing.yaml
+++ b/jxboot-resources/templates/700-docker-ing.yaml
@@ -9,6 +9,9 @@ metadata:
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
 {{- end }}
+{{- if index .Values "docker-registry" "ingress" "annotations" }}
+{{ toYaml (index .Values "docker-registry" "ingress" "annotations") | indent 4 }}
+{{- end }}
   name: docker-registry
 spec:
   rules:

--- a/jxboot-resources/templates/700-hook-ing.yaml
+++ b/jxboot-resources/templates/700-hook-ing.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
 {{- end }}
+{{- if .Values.hook.ingress.annotations }}
+{{ toYaml .Values.hook.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   rules:
   - host: hook{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}

--- a/jxboot-resources/templates/700-jenkins-ing.yaml
+++ b/jxboot-resources/templates/700-jenkins-ing.yaml
@@ -7,6 +7,9 @@ metadata:
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
 {{- end }}
+{{- if .Values.jenkins.ingress.annotations }}
+{{ toYaml .Values.jenkins.ingress.annotations | indent 4 }}
+{{- end }}
   name: jenkins
 spec:
   rules:

--- a/jxboot-resources/templates/700-nexus-ing.yaml
+++ b/jxboot-resources/templates/700-nexus-ing.yaml
@@ -7,6 +7,9 @@ metadata:
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
 {{- end }}
+{{- if .Values.nexus.ingress.annotations }}
+{{ toYaml .Values.nexus.ingress.annotations | indent 4 }}
+{{- end }}
   name: nexus
 spec:
   rules:

--- a/jxboot-resources/templates/700-tide-ing.yaml
+++ b/jxboot-resources/templates/700-tide-ing.yaml
@@ -9,6 +9,9 @@ metadata:
 {{- if .Values.cluster.ingress.annotations }}
 {{ toYaml .Values.cluster.ingress.annotations | indent 4 }}
 {{- end }}
+{{- if .Values.tide.ingress.annotations }}
+{{ toYaml .Values.tide.ingress.annotations | indent 4 }}
+{{- end }}
   name: tide
 spec:
   rules:

--- a/jxboot-resources/values.yaml
+++ b/jxboot-resources/values.yaml
@@ -6,6 +6,7 @@ bucketrepo:
   password: ""
   username: ""
   ingress:
+    annotations:
     tls:
       secretName: ""
 certmanager:
@@ -30,6 +31,7 @@ cluster:
 docker-registry:
   enabled: false
   ingress:
+    annotations:
     tls:
       secretName: ""
 gitops:
@@ -77,11 +79,13 @@ gitops:
 hook:
   ingress:
     class: nginx
+    annotations:
     tls:
       secretName: ""
 jenkins:
   enabled: false
   ingress:
+    annotations:
     tls:
       secretName: ""
 jenkins-x-platform:
@@ -90,6 +94,7 @@ jenkins-x-platform:
     ingress: true
 chartmuseum:
   ingress:
+    annotations:
     tls:
       secretName: ""
 lighthouse:
@@ -98,16 +103,19 @@ mergeUpdatebotPRs: true
 nexus:
   enabled: true
   ingress:
+    annotations:
     tls:
       secretName: ""
 prow:
   enabled: false
 tide:
   ingress:
+    annotations:
     tls:
       secretName: ""
 deck:
   ingress:
+    annotations:
     tls:
       secretName: ""
 storage:


### PR DESCRIPTION
add an `annotations` value for each ingress, to allow per-ingress annotations
(previously, annotations were global to all ingresses)