### PR TITLE
fix: Fix API Version for OpenShift SCC

### DIFF
--- a/jxboot-resources/templates/scc-controllerbuild.yaml
+++ b/jxboot-resources/templates/scc-controllerbuild.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.cluster.provider "openshift") ( eq .Values.cluster.strictPermissions false) }}
-apiVersion: v1
+apiVersion: security.openshift.io/v1
 defaultAddCapabilities: []
 allowHostDirVolumePlugin: false
 allowHostIPC: false


### PR DESCRIPTION
Fixing no matches for kind "SecurityContextConstraints" in version "v1" for OpenShift installation